### PR TITLE
New Feature: gemloader scripts now automatically determine bitfile size in bytes

### DIFF
--- a/scripts/gemloader/gemloader_clear_header.sh
+++ b/scripts/gemloader/gemloader_clear_header.sh
@@ -5,9 +5,7 @@ current_addr=$base_addr
 
 for i in $(seq 0 1 23)
 do
-
 	current_addr=$((base_addr+$i*4))
 	printf "clearing address 0x%x\n" $current_addr
 	poke $current_addr 0xffffffff
-
 done

--- a/scripts/gemloader/gemloader_configure.sh
+++ b/scripts/gemloader/gemloader_configure.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
 
-#LOAD_BIT_FILE=/mnt/persistent/texas/oh_fw/evka_ohv3a_test0.bit
-LOAD_BIT_FILE=/mnt/persistent/texas/oh_fw/OH-20180306-3.1.0.B.bit
-#LOAD_BIT_FILE=/mnt/persistent/texas/oh_fw/OH-20180223-3.0.10.A.bit
+LOAD_BIT_FILE=/mnt/persistent/gemdaq/oh_fw/optohybrid_top.bit
+SIZE_BIT_FILE=$(stat -c %s $(readlink -f /mnt/persistent/gemdaq/oh_fw/optohybrid_top.bit) )
 
-echo "Loading $LOAD_BIT_FILE"
+echo "Loading $LOAD_BIT_FILE with size $SIZE_BIT_FILE bytes"
 gemloader load $LOAD_BIT_FILE
-#/mnt/persistent/texas/tamu/gemloader/gemloader_clear_header.sh
 
-mpoke 0x6a000000 1       #enable the loader fw core
-#mpoke 0x6a000004 7694183 #number of bytes to load -- OTMB mez (v6 190T)
-mpoke 0x6a000004 5465074 #number of bytes to load -- OHv3a (v6 130T)
-#mpoke 0x6a000004 5465091 #number of bytes to load -- OHv3b (v6 130T)
+mpoke 0x6a000000 1              #enable the loader fw core
+mpoke 0x6a000004 $SIZE_BIT_FILE #number of bytes to load

--- a/scripts/gemloader/gemloader_load_test_data.sh
+++ b/scripts/gemloader/gemloader_load_test_data.sh
@@ -3,11 +3,11 @@
 base_addr=0x1f000000
 current_addr=$base_addr
 
-for i in $(seq 0 1 5465074)
-do
+SIZE_BIT_FILE=$(stat -c %s $(readlink -f /mnt/persistent/gemdaq/oh_fw/optohybrid_top.bit) )
 
+for i in $(seq 0 1 $SIZE_BIT_FILE)
+do
 	current_addr=$((base_addr+$i*4))
 	printf "clearing address 0x%x\n" $current_addr
 	poke $current_addr 0xffffffff
-
 done

--- a/scripts/gemloader/gemloader_read.sh
+++ b/scripts/gemloader/gemloader_read.sh
@@ -5,9 +5,7 @@ current_addr=$base_addr
 
 for i in $(seq 0 1 40)
 do
-
 	current_addr=$((base_addr+$i*4))
 	printf "reading address 0x%x\n" $current_addr
 	peek $current_addr
-
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
OHv3 FW bitfile size has changed between OHv3a and OHv3b/c and will most likely change again in the future.  Rather than having a hardcoded size in bytes these changes will automatically determine the file size in bytes and use this to set register `0x6a000004`.

@jsturdy @mexanick @evka85 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
http://cmsonline.cern.ch/cms-elog/1081982

The current size allocated to `0x6a000004` is about 17 bytes too small for the current OHv3 FW; this is 4-5 32 bit words.  I'm not sure how this impacts the PROM-less programming but I suspect that memory allocation should match what needs to be allocated.

These changes will automatically determine the size, in bytes, needed and write it to `0x6a000004`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
eagle35:/mnt/persistent/gemdaq/gemloader$ ./gemloader_configure.sh 
Loading /mnt/persistent/gemdaq/oh_fw/optohybrid_top.bit with size 5465091 bytes
Buffering
Zeroing 1
Zeroing 2
Writing 1
Writing 2
Verifying -- Reading
Verifying -- Comparing
Done
eagle35:/mnt/persistent/gemdaq/gemloader$ mpeek 0x6a000004
0x00536403
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
